### PR TITLE
Add support for oegdb

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,1 @@
+-Dsbt.supershell=never

--- a/build.sbt
+++ b/build.sbt
@@ -162,12 +162,12 @@ watchSources ++=
 
 val synthTestDataTask = TaskKey[Unit]("synthTestData", "Synthesizes test data.")
 
-val sgxGdbTask =
-  TaskKey[Unit]("sgx-gdb-task", "Runs OpaqueSinglePartitionSuite under the sgx-gdb debugger.")
-def sgxGdbCommand = Command.command("sgx-gdb") { state =>
+val oeGdbTask =
+  TaskKey[Unit]("oe-gdb-task", "Runs SinglePartitionJoinSuite under the oe-gdb debugger.")
+def oeGdbCommand = Command.command("oe-gdb") { state =>
   val extracted = Project extract state
   val newState = extracted.append(Seq(buildType := Debug), state)
-  Project.extract(newState).runTask(sgxGdbTask, newState)
+  Project.extract(newState).runTask(oeGdbTask, newState)
   state
 }
 
@@ -184,7 +184,7 @@ def keys = Command.command("keys") { state =>
   state
 }
 
-commands += sgxGdbCommand
+commands += oeGdbCommand
 commands += data
 
 initialCommands in console :=
@@ -247,11 +247,11 @@ nativePlatform := {
   }
 }
 
-sgxGdbTask := {
+oeGdbTask := {
   (compile in Test).value
   Process(
     Seq(
-      "sgx-gdb",
+      "/opt/openenclave/bin/oegdb",
       "java",
       "-x",
       ((baseDirectory in ThisBuild).value / "project" / "resources" / "run-tests.gdb").getPath

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,10 @@ watchSources ++=
 val synthTestDataTask = TaskKey[Unit]("synthTestData", "Synthesizes test data.")
 
 val oeGdbTask =
-  TaskKey[Unit]("oe-gdb-task", "Runs SinglePartitionJoinSuite under the oe-gdb debugger.")
+  TaskKey[Unit](
+    "oe-gdb-task",
+    "Runs the test suite specified in ./project/resources under the oe-gdb debugger."
+  )
 def oeGdbCommand = Command.command("oe-gdb") { state =>
   val extracted = Project extract state
   val newState = extracted.append(Seq(buildType := Debug), state)
@@ -251,7 +254,7 @@ oeGdbTask := {
   (compile in Test).value
   Process(
     Seq(
-      "/opt/openenclave/bin/oegdb",
+      "oegdb",
       "java",
       "-x",
       ((baseDirectory in ThisBuild).value / "project" / "resources" / "run-tests.gdb").getPath

--- a/docs/src/contributing/contributing.rst
+++ b/docs/src/contributing/contributing.rst
@@ -51,4 +51,12 @@ Opaque SQL enforces linting rules for all contributions. Before making changes a
 Debugging your changes
 ######################
 
-Opaque SQL supports debugging native C/C++ code with `oegdb <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Debugging.md>`_. To do so, specify the test class you want to debug in ``${OPAQUE_HOME}/project/resources/run-tests.gdb`` then run ``${OPAQUE_HOME}/build/sbt oe-gdb``.
+Opaque SQL supports debugging native C/C++ code with `oegdb <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Debugging.md>`_. There are three steps to do so:
+
+1. Specify the test suite you want to debug in ``${OPAQUE_HOME}/project/resources/run-tests.gdb``.
+
+2. Set a debug environment variable: ``export DEBUG=1``.
+
+3. Run ``${OPAQUE_HOME}/build/sbt oe-gdb``
+
+Note that setting ``DEBUG=1`` builds the enclave code in an insecure state: this **should not** be set for any production system.

--- a/docs/src/contributing/contributing.rst
+++ b/docs/src/contributing/contributing.rst
@@ -4,6 +4,9 @@
 Contributing
 ************
 
+Submitting a pull request
+#########################
+
 Opaque SQL enforces linting rules for all contributions. Before making changes and opening a pull request, please do the following (compatible for Ubuntu 18.04):
 
 #. Fork the repository on Github, then clone your fork and set upstream:
@@ -44,3 +47,8 @@ Opaque SQL enforces linting rules for all contributions. Before making changes a
    .. code-block:: bash
 
                 ./${OPAQUE_HOME}/format.sh
+
+Debugging your changes
+######################
+
+Opaque SQL supports debugging native C/C++ code with `oegdb <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Debugging.md>`_. To do so, specify the test class you want to debug in ``${OPAQUE_HOME}/project/resources/run-tests.gdb`` then run ``${OPAQUE_HOME}/build/sbt oe-gdb``.

--- a/project/resources/run-tests.gdb
+++ b/project/resources/run-tests.gdb
@@ -5,5 +5,5 @@ commands
 bt
 c
 end
-r -Xmx2048m org.scalatest.run edu.berkeley.cs.rise.opaque.OpaqueSinglePartitionSuite
+r -Xmx2048m org.scalatest.run edu.berkeley.cs.rise.opaque.SinglePartitionJoinSuite
 bt

--- a/src/enclave/App/App.cpp
+++ b/src/enclave/App/App.cpp
@@ -193,6 +193,9 @@ JNIEXPORT jlong JNICALL Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_St
 #ifdef SIMULATE
   flags |= OE_ENCLAVE_FLAG_SIMULATE;
 #endif
+#ifdef DEBUG
+  flags |= OE_ENCLAVE_FLAG_DEBUG;
+#endif
 
   const char *library_path_str = env->GetStringUTFChars(library_path, nullptr);
   oe_check_and_time("StartEnclave",

--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -42,7 +42,7 @@ if ("$ENV{MODE}" STREQUAL "SIMULATE")
   target_compile_definitions(enclave_trusted PUBLIC -DSIMULATE)
 endif()
 
-if ("$ENV{DEBUG}" STREQUAL "1")
+if ("$ENV{DEBUG}" EQUAL 1)
   target_compile_options(enclave_trusted PUBLIC -g -O0)
   target_compile_definitions(enclave_trusted PUBLIC -DDEBUG)
 endif()

--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -42,6 +42,11 @@ if ("$ENV{MODE}" STREQUAL "SIMULATE")
   target_compile_definitions(enclave_trusted PUBLIC -DSIMULATE)
 endif()
 
+if ("$ENV{DEBUG}" STREQUAL "1")
+  target_compile_options(enclave_trusted PUBLIC -g -O0)
+  target_compile_definitions(enclave_trusted PUBLIC -DDEBUG)
+endif()
+
 target_compile_definitions(enclave_trusted PUBLIC OE_API_VERSION=2)
 
 # Need for the generated file Enclave_t.h

--- a/src/enclave/Enclave/util.cpp
+++ b/src/enclave/Enclave/util.cpp
@@ -35,8 +35,11 @@ std::string string_format(const std::string &fmt, ...) {
 }
 
 void ocall_malloc(size_t size, uint8_t **ret) {
+// TODO: why do we need the ifndef here when running oegdb?
+#ifndef DEBUG
   // Guard against overwriting enclave memory
   assert(oe_is_outside_enclave(*ret, size) == 1);
+#endif
   __builtin_ia32_lfence();
   *ret = (uint8_t *)oe_host_malloc(size);
 }


### PR DESCRIPTION
This PR fixes the previously broken SBT task to run a test suite with a debugger. A couple of things to note:
1. Changing the test suite to run requires modifying project/resources/run-tests.gdb. I tried to make it so it can be supplied through the commandline like `build/sbt 'oe-gdb edu.berkeley.cs.rise.opaque.SinglePartitionJoinSuite'`, but the actual SBT task requires a modified state created in `oeGdbCommand`. It is only possible to return a modified state from a task (even this is deprecated), not modify it mid task. In order to parse in command-line arguments (`edu.berkeley.cs.rise.opaque.SinglePartitionJoinSuite` in this case), we need to use `InputKey` instead of `TaskKey`. The problem is that `runInputTask` accepts a different set of inputs than the ones specified in the commandline, and it is not possible to access commandline arguments through the parser outside of an input task definition (in this case `oeGdbCommand`).
2. All javaOptions for sbt-launch.jar in build.sbt are currently not being set. The custom sbt runner we use, build/sbt, defines its own set of Java options in `default_jvm_opts_common`. This runner allows us to specify a file for custom JVM options, .jvmopts, but we cannot set command/task-specific JVM options through this (`javaOptions in oe-gdb`, which we need). For GDB to work, we need to set `-Dsbt.supershell=never` because otherwise the commands to gdb through `build/sbt oe-gdb` continuously get overridden by a terminal refresh, making reading what was already written impossible.
3. There is an assertion in `ocall_malloc` that is failing. I disabled this only for the DEBUG case, but it is strange because `oe_is_outside_enclave` is passing in all other cases.

Planning on making tasks for all these to fix later, but for now GDB works and I think we have other priorities. Let me know if you have concerns though.