### PR TITLE
Use NSDI Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Congrats, you've run your first encrypted query using Opaque SQL!
 For more details on building, using, and contributing, please see our [documentation](https://mc2-project.github.io/opaque/). 
 
 ### Paper
-The open source is based on our NSDI 2017 [paper](https://people.eecs.berkeley.edu/~wzheng/opaque.pdf).
+The open source is based on our NSDI 2017 [paper](https://www.usenix.org/system/files/conference/nsdi17/nsdi17-zheng.pdf).

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -16,7 +16,7 @@ Unlike the Spark cluster, the driver must be run within a trusted environment (e
 - Computation integrity verification (section 4.2 of the NSDI paper) is currently work in progress.
 
 [1] Wenting Zheng, Ankur Dave, Jethro Beekman, Raluca Ada Popa, Joseph Gonzalez, and Ion Stoica.
-`Opaque: An Oblivious and Encrypted Distributed Analytics Platform <https://people.eecs.berkeley.edu/~wzheng/opaque.pdf>`_. NSDI 2017, March 2017.
+`Opaque: An Oblivious and Encrypted Distributed Analytics Platform <https://www.usenix.org/system/files/conference/nsdi17/nsdi17-zheng.pdf>`_. NSDI 2017, March 2017.
 
 
 .. toctree::


### PR DESCRIPTION
Replace the original link to the paper (invalidated by disabled Berkeley EECS page) with one hosted by NSDI.