### PR TITLE
Add binary evaluation comparison on boolean fields

### DIFF
--- a/src/cpp/enclave/flatbuffer_helpers/expression_evaluation.h
+++ b/src/cpp/enclave/flatbuffer_helpers/expression_evaluation.h
@@ -108,6 +108,12 @@ eval_binary_comparison(flatbuffers::FlatBufferBuilder &builder, const tuix::Fiel
   bool result = false;
   if (!result_is_null) {
     switch (left->value_type()) {
+    case tuix::FieldUnion_BooleanField: {
+      result =
+          Operation<bool>()(static_cast<const tuix::BooleanField *>(left->value())->value(),
+                            static_cast<const tuix::BooleanField *>(right->value())->value());
+      break;
+    }
     case tuix::FieldUnion_IntegerField: {
       result =
           Operation<int32_t>()(static_cast<const tuix::IntegerField *>(left->value())->value(),

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/SortSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/SortSuite.scala
@@ -93,7 +93,7 @@ trait SortSuite extends OpaqueSuiteBase with SQLHelper {
     }
   }
 
-  ignore("sorting after union before aggregate") {
+  test("sorting after union before aggregate") {
     checkAnswer() { sl =>
       val one = sl.applyTo(
         Seq[(Integer, Boolean, Boolean)]((1, true, false), (2, false, true), (10, true, false))

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/SortSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/SortSuite.scala
@@ -93,6 +93,27 @@ trait SortSuite extends OpaqueSuiteBase with SQLHelper {
     }
   }
 
+  ignore("sorting after union before aggregate") {
+    checkAnswer() { sl =>
+      val one = sl.applyTo(
+        Seq[(Integer, Boolean, Boolean)]((1, true, false), (2, false, true), (10, true, false))
+          .toDF("id", "value", "value2")
+      )
+      one.createOrReplaceTempView("one")
+
+      val two = sl.applyTo(
+        Seq[(Integer, Boolean, Boolean)]((20, true, true), (30, false, false), (50, false, true))
+          .toDF("id", "value", "value2")
+      )
+      two.createOrReplaceTempView("two")
+
+      spark.sql("""
+      |SELECT value AND value2 FROM one
+      |UNION
+      |SELECT value AND value2 FROM two""".stripMargin)
+    }
+  }
+
   def generateRandomPairs(numPairs: Int = 1000) = {
     val rand = new scala.util.Random()
     Seq.fill(numPairs) { (rand.nextInt(), rand.nextInt()) }.toDF


### PR DESCRIPTION
Previously, our sort was failing on booleans because it did not know how to compare them.