### PR TITLE
Split out usage section from the untrusted docs page

### DIFF
--- a/opaque-sql-docs/src/index.rst
+++ b/opaque-sql-docs/src/index.rst
@@ -23,6 +23,7 @@ It currently has the following limitations:
 
    install/install.rst
    usage/client.rst
+   usage/untrusted.rst
    usage/usage.rst
    usage/functionality.rst
    benchmarking/benchmarking.rst

--- a/opaque-sql-docs/src/usage/functionality.rst
+++ b/opaque-sql-docs/src/usage/functionality.rst
@@ -4,7 +4,7 @@
 Supported functionalities
 *************************
 
-This section lists Opaque's supported functionalities, which is a subset of that of Spark SQL. Note that the syntax for these functionalities is the same as Spark SQL -- Opaque simply replaces the execution to work with encrypted data.
+This section lists Opaque's supported functionalities, which is a subset of that of Spark SQL. The syntax for these functionalities is the same as Spark SQL -- Opaque simply replaces the execution to work with encrypted data.
 
 SQL interface
 #############

--- a/opaque-sql-docs/src/usage/untrusted.rst
+++ b/opaque-sql-docs/src/usage/untrusted.rst
@@ -1,0 +1,142 @@
+*************************************
+Query submission via the Spark Driver
+*************************************
+
+.. figure:: https://mc2-project.github.io/opaque-sql/opaque-diagram.svg
+   :align: center
+   :figwidth: 100 %
+
+   Overview of Opaque SQL running in insecure mode
+
+
+
+Starting Opaque SQL
+###################
+
+This page goes through running Opaque SQL with the Spark driver located on the client. 
+
+.. warning::
+      This mode **should not** be used in any context where the full security of hardware enclaves is required. Remote attestation is disabled, and the Spark Driver has access to the key the worker enclaves use to encrypt/decrypt data. This is still offered to play around with the project and explore its API.
+
+      This is Opaque SQL in **insecure** mode, and is normally only used for testing functionalities.
+
+Running the interactive shell
+*****************************
+
+
+1. Package Opaque into a fat JAR. The reason we need a fat JAR is because the JAR produced by ``build/sbt package`` does not include gRPC dependencies needed for remote attestion.
+
+   .. code-block:: bash
+                   
+                   cd ${OPAQUE_HOME}
+                   build/sbt test:assembly
+
+2. Launch the Spark shell with Opaque.
+
+   Scala:
+
+   .. code-block:: bash
+
+                   spark-shell --jars ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar
+
+   Python:
+
+   .. code-block:: bash
+                   
+                   pyspark --py-files ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar  \
+                     --jars ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar
+    
+   (we need to specify `--py-files` because the Python functions are placed in the .jar for easier packaging)
+
+3. Alternatively, you can also run queries in Scala locally using ``sbt``.
+
+   .. code-block:: bash
+
+                   build/sbt console
+    
+4. Inside the Spark shell, import Opaque SQL's ``DataFrame`` methods and its query planning rules.
+
+   Scala:
+
+   .. code-block:: scala
+
+                     import edu.berkeley.cs.rise.opaque.implicits._
+                     edu.berkeley.cs.rise.opaque.Utils.initOpaqueSQL(spark, testing = true)
+
+   Python:
+
+   .. code-block:: python
+
+                  from opaque_sql import *
+                  init_opaque_sql(testing=True)
+                   
+    
+
+
+
+Encrypting a DataFrame with the Driver
+######################################
+
+.. note::
+  The methods shown in this section are *only* supported in insecure mode.
+
+1. Create an unencrypted DataFrame.
+
+   Scala:
+
+   .. code-block:: scala
+                   
+                   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5))
+                   val df = spark.createDataFrame(data).toDF("word", "count")
+
+   Python:
+
+   .. code-block:: python
+                   
+                  data = [("foo", 4), ("bar", 1), ("baz", 5)]
+                  df = sqlContext.createDataFrame(data).toDF("word", "count")
+
+2. Create an encrypted DataFrame from the unencrypted version. In insecure mode, this is as easy as calling ``.encrypted``.
+
+   Scala:
+   
+   .. code-block:: scala
+                   
+                   val dfEncrypted = df.encrypted
+
+   Python:
+
+   .. code-block:: python
+                   
+                  df_encrypted = df.encrypted()
+
+
+3. Perform any operations in the :ref:`list of supported functionalities <functionalities>`.
+
+3. Call ``.collect`` or ``.show`` to retreive and automatically decrypt the results.
+
+   Scala:
+   
+   .. code-block:: scala
+                   
+                  dfEncrypted.show
+                  // +-----+-----+
+                  // |word |count|
+                  // +--99-+-----+
+                  // |  foo|    4|
+                  // |  bar|    1|
+                  // |  baz|    5|
+                  // +-----+-----+
+
+   Python:
+
+   .. code-block:: python
+                   
+                  df_encrypted.show
+                  # +-----+-----+
+                  # |word |count|
+                  # +--99-+-----+
+                  # |  foo|    4|
+                  # |  bar|    1|
+                  # |  baz|    5|
+                  # +-----+-----+

--- a/opaque-sql-docs/src/usage/usage.rst
+++ b/opaque-sql-docs/src/usage/usage.rst
@@ -1,127 +1,29 @@
-*************************************
-Query submission via the Spark Driver
-*************************************
+*****
+Usage
+*****
 
-.. figure:: https://mc2-project.github.io/opaque-sql/opaque-diagram.svg
-   :align: center
-   :figwidth: 100 %
+This section goes over how to manipulate an encrypted DataFrame in either client or insecure mode. 
 
-   Overview of Opaque SQL running in insecure mode
-
-
-
-Starting Opaque SQL
-###################
-
-This page goes through running Opaque SQL with the Spark driver located on the client. 
-
-.. warning::
-      This mode **should not** be used in any context where the full security of hardware enclaves is required. Remote attestation is disabled, and the Spark Driver has access to the key the worker enclaves use to encrypt/decrypt data. This is still offered to play around with the project and explore its API.
-
-      This is Opaque SQL in **insecure** mode, and is normally only used for testing functionalities.
-
-Running the interactive shell
-*****************************
-
-
-1. Package Opaque into a fat JAR. The reason we need a fat JAR is because the JAR produced by ``build/sbt package`` does not include gRPC dependencies needed for remote attestion.
-
-   .. code-block:: bash
-                   
-                   cd ${OPAQUE_HOME}
-                   build/sbt test:assembly
-
-2. Launch the Spark shell with Opaque.
-
-   Scala:
-
-   .. code-block:: bash
-
-                   spark-shell --jars ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar
-
-   Python:
-
-   .. code-block:: bash
-                   
-                   pyspark --py-files ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar  \
-                     --jars ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar
-    
-   (we need to specify `--py-files` because the Python functions are placed in the .jar for easier packaging)
-
-3. Alternatively, you can also run queries in Scala locally using ``sbt``.
-
-   .. code-block:: bash
-
-                   build/sbt console
-    
-4. Inside the Spark shell, import Opaque SQL's ``DataFrame`` methods and its query planning rules.
-
-   Scala:
-
-   .. code-block:: scala
-
-                     import edu.berkeley.cs.rise.opaque.implicits._
-                     edu.berkeley.cs.rise.opaque.Utils.initOpaqueSQL(spark, testing = true)
-
-   Python:
-
-   .. code-block:: python
-
-                  from opaque_sql import *
-                  init_opaque_sql(testing=True)
-                   
-    
-
-
-
-Encrypting, saving, and loading a DataFrame
-###########################################
-
-1. Create an unencrypted DataFrame.
-
-   Scala:
-
-   .. code-block:: scala
-                   
-                   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5))
-                   val df = spark.createDataFrame(data).toDF("word", "count")
-
-   Python:
-
-   .. code-block:: python
-                   
-                  data = [("foo", 4), ("bar", 1), ("baz", 5)]
-                  df = sqlContext.createDataFrame(data).toDF("word", "count")
-
-2. Create an encrypted DataFrame from the unencrypted version. Opaque SQL makes this as easy as calling ``.encrypted`` (*note*: this call is only supported in insecure mode).
-
-   Scala:
-   
-   .. code-block:: scala
-                   
-                   val dfEncrypted = df.encrypted
-
-   Python:
-
-   .. code-block:: python
-                   
-                  df_encrypted = df.encrypted()
+.. note::
+  Currently, Python is only supported while running in **insecure** mode.
 
 .. _save_df:
 
-3. Save the encrypted DataFrame to local disk.
-   The encrypted data can also be uploaded to cloud storage for easy access.
+Saving a DataFrame
+##################
 
-   Scala:
+Save the encrypted DataFrame to local disk. The encrypted data can then be uploaded to cloud storage of your choice for easy access.
 
-   .. code-block:: scala
+Scala:
+
+.. code-block:: scala
                    
                    dfEncrypted.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("dfEncrypted")
                    // The file dfEncrypted/part-00000 now contains encrypted data
 
-   Python:
+Python:
 
-   .. code-block:: python
+.. code-block:: python
                    
                   df_encrypted.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("df_encrypted")
 
@@ -145,7 +47,7 @@ Using the DataFrame interface
                    
                   df_encrypted = spark.read.format("edu.berkeley.cs.rise.opaque.EncryptedSource").load("df_encrypted")
 
-2. Given an encrypted DataFrame , construct a new query. Users can use ``explain`` to see the generated query plan.
+2. Given an encrypted DataFrame, construct a new query. Users can use ``explain`` to see the generated query plan.
 
    Scala:
 
@@ -166,8 +68,6 @@ Using the DataFrame interface
                   result = df_encrypted.filter(df_encrypted["count"] > 3)
                   result.explain(True)
                    
-Call ``.collect`` or ``.show`` to retreive and automatically decrypt the results.
-
 
 Using the SQL interface
 #######################
@@ -191,4 +91,3 @@ Using the SQL interface
                      |SELECT * FROM dfEncrypted
                      |WHERE count > 3""".stripMargin)
                    result.show
-


### PR DESCRIPTION
This PR creates a dedicated page for walking the user through using Opaque SQL when querying from the MC^2 Client or in insecure mode.