### PR TITLE
Change accent color

### DIFF
--- a/opaque-sql-docs/src/conf.py
+++ b/opaque-sql-docs/src/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
     "light_css_variables": {
         "color-brand-primary": "#00B0FF",
         "color-brand-content": "#00B0FF",
-        "color-admonition-background": "orange",
+        "color-admonition-background": "#3681da",
     },
 }
 


### PR DESCRIPTION
This changes the accent color of the Opaque SQL docs to match the client -- the current color is a bit harsh.

Before:
<img width="1414" alt="Screen Shot 2021-06-17 at 12 04 09 PM" src="https://user-images.githubusercontent.com/13458837/122459055-520a8600-cf65-11eb-803a-9a233cceaec2.png">

After:
<img width="1394" alt="Screen Shot 2021-06-17 at 12 09 01 PM" src="https://user-images.githubusercontent.com/13458837/122459092-5cc51b00-cf65-11eb-91ca-b07a305a1239.png">

