### PR TITLE
Automate consolidated documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,17 @@ jobs:
         git config --local user.name "GitHub Action"
         git add .
         git commit -m "${GITHUB_ACTOR}'s changes in ${GITHUB_SHA} triggered this build" -a || true
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         branch: gh-pages
         directory: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update MC2 website
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.MC2_BOT_PAT }}
+        repository: mc2-project/mc2-project.github.io
+        event-type: opaque-sql-docs-dispatch


### PR DESCRIPTION
This PR adds a dispatch action to the CI that notifies the [documentation repo](https://github.com/mc2-project/mc2-project.github.io) to rebuild and regenerate documentation upon every push to master in this Opaque SQL repo. 

This action essentially makes a request to the documentation repo to rebuild upon every push to master. The documentation repo listens for this request [here](https://github.com/mc2-project/mc2-project.github.io/blob/master/.github/workflows/docs.yml#L11). Once the documentation repo receives this request, it'll automatically regenerate the documentation and publish it online.