### PR TITLE
Fix merge strategy

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/RA.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/RA.scala
@@ -90,6 +90,8 @@ object RA extends Logging {
 
     // Start gRPC server to listen for attestation inquiries
     val port = 50051
+    // Need to use netty
+    // See https://scalapb.github.io/docs/grpc/#grpc-netty-issues
     val server = NettyServerBuilder
       .forPort(port)
       .addService(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/Listener.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/Listener.scala
@@ -59,6 +59,8 @@ class Listener(executionContext: ExecutionContext, port: Int) {
   }
 
   private def start(): Unit = {
+    // Need to use netty
+    // See https://scalapb.github.io/docs/grpc/#grpc-netty-issues
     server = NettyServerBuilder
       .forPort(port)
       .addService(ListenerGrpc.bindService(new ListenerImpl, executionContext))


### PR DESCRIPTION
Our previous merge strategy simply discarded everything in META-INF, and the new client channel connection needs a file in that folder. Therefore, when we packaged a fat jar and submitted to Spark, it failed despite working in `build/sbt run`.