### PR TITLE
No extraneous errors when running the listener

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,9 +91,9 @@ assemblyShadeRules in (Test, assembly) := commonShadeRules
 testOptions in Test += Tests.Argument("-oF")
 
 lazy val commonJavaOptions =
-  Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-Dlog4j.configuration=log4j.properties")
-javaOptions in Test ++= commonJavaOptions
-javaOptions in run ++= commonJavaOptions ++ Seq("-Dspark.master=local[*]")
+  Seq("-Xmx4096m", "-XX:ReservedCodeCacheSize=384m")
+Test / javaOptions := commonJavaOptions
+run / javaOptions := commonJavaOptions ++ Seq("-Dspark.master=local[1]")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 # Set everything to be logged to the console
 log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
+log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,7 +1,7 @@
 # Set everything to be logged to the console
 log4j.rootCategory=WARN, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
+log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 


### PR DESCRIPTION
This PR removes the extraneous errors found at the start of `build/sbt run`.

In build.sbt, we don't set `-Dlog4j.configuration` so the launcher uses the default in src/main/resources. We explicitly override the java options for both `test` and `run`forks.

In IntpHandler.scala, we bind the Spark global variables to `intp`, so `intp` inherits logging and other spark configs from the main java process.

In log4j.properties, we set `log4j.appender.console.target` to print to stdout instead of stderr.

Can't get rid of the `WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable".` without introducing a Hadoop dependency: https://stackoverflow.com/questions/40015416/spark-unable-to-load-native-hadoop-library-for-your-platform. It's fine to use the Java classes, since we don't need HDFS for a local listener anyway.